### PR TITLE
Users can now edit and delete items.

### DIFF
--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -35,10 +35,7 @@ class HomePage extends StatelessWidget {
   Widget _buildDrawer(BuildContext context) {
     return Container(
       height: double.infinity,
-      width: MediaQuery
-          .of(context)
-          .size
-          .width / 1.4,
+      width: MediaQuery.of(context).size.width / 1.4,
       decoration: BoxDecoration(
         color: Color.fromRGBO(20, 20, 20, 1),
       ),

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -5,8 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 class HomePage extends StatelessWidget {
-
-
   void addExpense(BuildContext context) {
     showModalBottomSheet(
       context: context,
@@ -14,11 +12,10 @@ class HomePage extends StatelessWidget {
         return AddExpenseWidget();
       },
       shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.only(
-          topLeft: Radius.circular(40),
-          topRight: Radius.circular(40),
-        )
-      ),
+          borderRadius: BorderRadius.only(
+        topLeft: Radius.circular(40),
+        topRight: Radius.circular(40),
+      )),
       enableDrag: true,
     );
   }
@@ -38,7 +35,10 @@ class HomePage extends StatelessWidget {
   Widget _buildDrawer(BuildContext context) {
     return Container(
       height: double.infinity,
-      width: MediaQuery.of(context).size.width/1.4,
+      width: MediaQuery
+          .of(context)
+          .size
+          .width / 1.4,
       decoration: BoxDecoration(
         color: Color.fromRGBO(20, 20, 20, 1),
       ),
@@ -50,13 +50,15 @@ class HomePage extends StatelessWidget {
       backgroundColor: Color.fromRGBO(71, 8, 154, 1),
       title: Text(
         'Expenses',
-        style: TextStyle(
-          fontSize: 17
-        ),
+        style: TextStyle(fontSize: 17),
       ),
       centerTitle: true,
       actions: [
-        IconButton(icon: Icon(Icons.mode_edit), onPressed: (){addExpense(context);})
+        IconButton(
+            icon: Icon(Icons.mode_edit),
+            onPressed: () {
+              addExpense(context);
+            })
       ],
     );
   }
@@ -76,23 +78,54 @@ class HomePage extends StatelessWidget {
     final _expenseListProvider = Provider.of<Expenses>(context);
     final List _expenseList = _expenseListProvider.expenseList;
     return ListView.builder(
-      itemCount: _expenseList.length,
-      itemBuilder: (_,index){
-        return ExpenseWidget(expense: _expenseList[index],);
-      }
-    );
+        itemCount: _expenseList.length,
+        itemBuilder: (_, index) {
+          return Dismissible(
+            key: Key(_expenseList[index].toString()),
+            onDismissed: (direction) {
+              _expenseList.removeAt(index);
+            },
+            confirmDismiss: (DismissDirection direction) async {
+              return await showDialog(
+                context: context,
+                builder: (BuildContext context) {
+                  return AlertDialog(
+                    title: const Text('Confirm'),
+                    content: const Text(
+                        'Are you sure you wish to delete this expense?'),
+                    actions: <Widget>[
+                      FlatButton(
+                          color: Colors.greenAccent,
+                          textColor: Colors.black87,
+                          onPressed: () => Navigator.of(context).pop(true),
+                          child: const Text('Yes, delete.')),
+                      FlatButton(
+                        color: Colors.redAccent,
+                        textColor: Colors.black87,
+                        onPressed: () => Navigator.of(context).pop(false),
+                        child: const Text('No, keep.'),
+                      ),
+                    ],
+                  );
+                },
+              );
+            },
+            child: ExpenseWidget(
+              expense: _expenseList[index],
+            ),
+          );
+        });
   }
 
   Widget _buildFloatingActionButton(BuildContext context) {
     return FloatingActionButton(
-      onPressed: (){
+      onPressed: () {
         addExpense(context);
-      }, 
+      },
       backgroundColor: Color.fromRGBO(71, 8, 154, 1),
       child: Center(
         child: Icon(Icons.add_box),
       ),
     );
   }
-
 }

--- a/lib/providers/expenses.dart
+++ b/lib/providers/expenses.dart
@@ -2,18 +2,20 @@ import 'package:Expense/models/expense.dart';
 import 'package:flutter/material.dart';
 
 class Expenses with ChangeNotifier {
-
   List<Expense> _expenseList = [
-    Expense(amount: 1800, itemDescription: "Grocery Items",time:DateTime.now() ),
-    Expense(amount: 120, itemDescription: "Stationary Items",time:DateTime.now() ),
-    
+    Expense(
+        amount: 1800, itemDescription: "Grocery Items", time: DateTime.now()),
+    Expense(
+        amount: 120, itemDescription: "Stationary Items", time: DateTime.now()),
   ];
 
-  List<Expense> get expenseList => _expenseList ;
+  List<Expense> get expenseList => _expenseList;
 
   void addToList(double amount, String itemDescription, {DateTime time}) {
-    _expenseList.add(Expense(amount: amount,itemDescription: itemDescription, time: DateTime.now()));
+    _expenseList.add(Expense(
+        amount: amount,
+        itemDescription: itemDescription,
+        time: DateTime.now()));
     notifyListeners();
   }
-
 }

--- a/lib/widgets/addExpense.dart
+++ b/lib/widgets/addExpense.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 class AddExpenseWidget extends StatefulWidget {
-
   @override
   _AddExpenseWidgetState createState() => _AddExpenseWidgetState();
 }
@@ -19,16 +18,16 @@ class _AddExpenseWidgetState extends State<AddExpenseWidget> {
     return Container(
       height: double.infinity,
       width: double.infinity,
-      margin: EdgeInsets.only(top: 38,left: 28,right: 28, bottom: 28),
+      margin: EdgeInsets.only(top: 38, left: 28, right: 28, bottom: 28),
       child: Form(
         child: Column(
           children: [
             TextFormField(
-              onChanged: (value){
-                amount=double.parse(value);
+              onChanged: (value) {
+                amount = double.parse(value);
               },
-              onFieldSubmitted: (value){
-                amount=double.parse(value);
+              onFieldSubmitted: (value) {
+                amount = double.parse(value);
                 print(amount);
               },
               style: TextStyle(
@@ -38,24 +37,23 @@ class _AddExpenseWidgetState extends State<AddExpenseWidget> {
               cursorRadius: Radius.circular(18),
               keyboardType: TextInputType.phone,
               decoration: InputDecoration(
-                hintText: "Amount",
-                hintStyle: TextStyle(
-                  fontSize: 18,
-                ),
-                focusedBorder:UnderlineInputBorder(
-                  borderSide: BorderSide(
-                    color: Color.fromRGBO(71, 8, 154, 1)
-                  )
-                ) 
-              ),
+                  hintText: "Amount",
+                  hintStyle: TextStyle(
+                    fontSize: 18,
+                  ),
+                  focusedBorder: UnderlineInputBorder(
+                      borderSide:
+                          BorderSide(color: Color.fromRGBO(71, 8, 154, 1)))),
             ),
-            SizedBox(height: 20,),
+            SizedBox(
+              height: 20,
+            ),
             TextFormField(
-              onChanged: (value){
-                item=value;
+              onChanged: (value) {
+                item = value;
               },
-              onFieldSubmitted: (value){
-                item=value;
+              onFieldSubmitted: (value) {
+                item = value;
                 print(item);
               },
               style: TextStyle(
@@ -65,36 +63,32 @@ class _AddExpenseWidgetState extends State<AddExpenseWidget> {
               cursorRadius: Radius.circular(18),
               keyboardType: TextInputType.emailAddress,
               decoration: InputDecoration(
-                hintText: "Item Description",
-                hintStyle: TextStyle(
-                  fontSize: 18,
-                ),
-                focusedBorder:UnderlineInputBorder(
-                  borderSide: BorderSide(
-                    color: Color.fromRGBO(71, 8, 154, 1)
-                  )
-                ) 
-              ),
+                  hintText: "Item Description",
+                  hintStyle: TextStyle(
+                    fontSize: 18,
+                  ),
+                  focusedBorder: UnderlineInputBorder(
+                      borderSide:
+                          BorderSide(color: Color.fromRGBO(71, 8, 154, 1)))),
             ),
             Expanded(child: Container()),
             Material(
               color: Color.fromRGBO(71, 8, 154, 1),
               borderRadius: BorderRadius.circular(18),
               child: InkWell(
-                onTap: (){
+                onTap: () {
                   if (amount == 0 || item == 'Empty') {
-                    _alertEmptyInput(amount == 0, item == 'Empty');
+                    _alertEmptyInput(amount == 0);
                   } else {
-                    _expenseListProvider.addToList(amount,item);
+                    _expenseListProvider.addToList(amount, item);
                     Navigator.pop(context);
                   }
                 },
                 child: Container(
                   height: 60,
                   width: double.infinity,
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(18)
-                  ),
+                  decoration:
+                  BoxDecoration(borderRadius: BorderRadius.circular(18)),
                   child: Center(
                     child: Text(
                       "Add Expense",
@@ -113,7 +107,7 @@ class _AddExpenseWidgetState extends State<AddExpenseWidget> {
     );
   }
 
-  Future<void> _alertEmptyInput(hasAmount, hasMessage) async {
+  Future<void> _alertEmptyInput(hasAmount) async {
     String empty = '';
     if (hasAmount) {
       empty = 'amount';

--- a/lib/widgets/expense.dart
+++ b/lib/widgets/expense.dart
@@ -1,6 +1,6 @@
 import 'package:Expense/models/expense.dart';
+import 'package:Expense/widgets/statefulText.dart';
 import 'package:flutter/material.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:intl/intl.dart';
 
 class ExpenseWidget extends StatelessWidget {
@@ -40,14 +40,7 @@ class ExpenseWidget extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.end,
         children: [
-          Text(
-            "${expense.amount}",
-            style: TextStyle(
-              fontSize: 38,
-              fontWeight: FontWeight.w600,
-              color: Color.fromRGBO(71, 8, 154, 1),
-            ),
-          ),
+          StatefulText(value: expense, isAmount: true),
           Container(
             margin: EdgeInsets.only(bottom: 7, left: 7),
             child: Column(
@@ -75,16 +68,7 @@ class ExpenseWidget extends StatelessWidget {
     return Container(
       margin: EdgeInsets.only(top: 2),
       width: double.infinity,
-      child: Text(
-        "${expense.itemDescription}",
-        textAlign: TextAlign.justify,
-        style: GoogleFonts.ubuntu(
-            textStyle: TextStyle(
-          color: Colors.black.withOpacity(0.8),
-          fontSize: 17,
-          fontWeight: FontWeight.w600,
-        )),
-      ),
+      child: StatefulText(value: expense, isAmount: false),
     );
   }
 

--- a/lib/widgets/expense.dart
+++ b/lib/widgets/expense.dart
@@ -4,7 +4,6 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:intl/intl.dart';
 
 class ExpenseWidget extends StatelessWidget {
-
   final Expense expense;
 
   ExpenseWidget({this.expense});
@@ -13,8 +12,8 @@ class ExpenseWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       width: double.infinity,
-      padding: EdgeInsets.only(top: 18,left: 18,right: 18,bottom: 10),
-      margin: EdgeInsets.only(left: 17,right: 17,top: 18),
+      padding: EdgeInsets.only(top: 18, left: 18, right: 18, bottom: 10),
+      margin: EdgeInsets.only(left: 17, right: 17, top: 18),
       decoration: BoxDecoration(
         color: Colors.white.withOpacity(1),
         borderRadius: BorderRadius.circular(18),
@@ -28,7 +27,7 @@ class ExpenseWidget extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.start,
       children: [
         _buildAmountDisplay(context),
-        _buildItemDisplay(context),  
+        _buildItemDisplay(context),
         _buildDateDisplay(context)
       ],
     );
@@ -46,11 +45,11 @@ class ExpenseWidget extends StatelessWidget {
             style: TextStyle(
               fontSize: 38,
               fontWeight: FontWeight.w600,
-              color: Color.fromRGBO(71 , 8, 154, 1),
+              color: Color.fromRGBO(71, 8, 154, 1),
             ),
           ),
           Container(
-            margin: EdgeInsets.only(bottom: 7,left: 7),
+            margin: EdgeInsets.only(bottom: 7, left: 7),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               mainAxisAlignment: MainAxisAlignment.end,
@@ -79,7 +78,8 @@ class ExpenseWidget extends StatelessWidget {
       child: Text(
         "${expense.itemDescription}",
         textAlign: TextAlign.justify,
-        style: GoogleFonts.ubuntu(textStyle: TextStyle(
+        style: GoogleFonts.ubuntu(
+            textStyle: TextStyle(
           color: Colors.black.withOpacity(0.8),
           fontSize: 17,
           fontWeight: FontWeight.w600,
@@ -102,7 +102,7 @@ class ExpenseWidget extends StatelessWidget {
               color: Color.fromRGBO(71, 8, 154, 1).withOpacity(0.8),
               borderRadius: BorderRadius.circular(18),
             ),
-            padding: EdgeInsets.symmetric(horizontal: 8,vertical: 2),
+            padding: EdgeInsets.symmetric(horizontal: 8, vertical: 2),
             child: Text(
               "$newDtHour $newDt",
               style: TextStyle(
@@ -115,5 +115,4 @@ class ExpenseWidget extends StatelessWidget {
       ),
     );
   }
-
 }

--- a/lib/widgets/statefulText.dart
+++ b/lib/widgets/statefulText.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+
+class StatefulText extends StatefulWidget {
+  final value;
+  final bool isAmount;
+
+  StatefulText({this.value, this.isAmount});
+
+  @override
+  _StatefulTextState createState() =>
+      _StatefulTextState(value: value, isAmount: isAmount);
+}
+
+class _StatefulTextState extends State<StatefulText> {
+  final value;
+  final isAmount;
+
+  final _textController = TextEditingController();
+
+  _StatefulTextState({this.value, this.isAmount});
+
+  @override
+  void dispose() {
+    _textController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {
+        _showEditDialog(context, isAmount);
+      },
+      child: Text(
+        isAmount ? '${value.amount}' : '${value.itemDescription}',
+        style: TextStyle(
+          fontSize: isAmount ? 38 : 17,
+          fontWeight: FontWeight.w600,
+          color: isAmount
+              ? Color.fromRGBO(71, 8, 154, 1)
+              : Colors.black.withOpacity(0.8),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _showEditDialog(BuildContext context, bool isAmount) {
+    var edit = isAmount ? 'Amount' : 'Description';
+
+    return showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: Text('Change $edit?'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                'Current $edit is ${isAmount ? value.amount : value.itemDescription}',
+                style: TextStyle(
+                  color: Colors.black.withOpacity(0.8),
+                ),
+              ),
+              TextField(
+                controller: _textController,
+                keyboardType: isAmount
+                    ? TextInputType.numberWithOptions(decimal: true)
+                    : TextInputType.text,
+                decoration: InputDecoration(
+                  hintText: 'Enter New $edit',
+                ),
+              ),
+            ],
+          ),
+          actions: <Widget>[
+            FlatButton(
+              child: Text('Yes, change.'),
+              color: Colors.greenAccent,
+              textColor: Colors.black87,
+              onPressed: () {
+                setState(() {
+                  if (isAmount) {
+                    value.amount = double.parse(_textController.text);
+                  } else {
+                    value.itemDescription = _textController.text;
+                  }
+                });
+                Navigator.of(context).pop();
+              },
+            ),
+            FlatButton(
+              child: Text('No, keep.'),
+              color: Colors.redAccent,
+              textColor: Colors.black87,
+              onPressed: () {
+                Navigator.of(context).pop();
+                _textController.clear();
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
# Changes

## Added Swipe to Dismiss
The user can swipe away the card they want to delete. The app will confirm their choice and take action accordingly. 

**To make the cards dismiss-able, I've wrapped the `ExpenseWidget` in `home.dart` with `Dismissible` widget.**

![Screenshot_1602145125](https://user-images.githubusercontent.com/29453365/95433419-87d68400-096d-11eb-8510-7fdcdd97a849.png)

## Added Tap to Edit
The users can tap on the amount or description that want to change and edit the values. 

**To make the text live and editable, I've added a new statefulText widget.**

![Screenshot_1602145235](https://user-images.githubusercontent.com/29453365/95433575-c3714e00-096d-11eb-9f40-8016bcd6ddc0.png)
![Screenshot_1602145246](https://user-images.githubusercontent.com/29453365/95433581-c4a27b00-096d-11eb-99b6-3c93835fffbb.png)
![Screenshot_1602145257](https://user-images.githubusercontent.com/29453365/95433583-c4a27b00-096d-11eb-9199-3ce15c9aee44.png)
![Screenshot_1602145260](https://user-images.githubusercontent.com/29453365/95433586-c53b1180-096d-11eb-92f8-c0a1c09d3f70.png)

